### PR TITLE
EC2 provisioning playbook added

### DIFF
--- a/inventories/staging/host_vars/ec2_variables.yml
+++ b/inventories/staging/host_vars/ec2_variables.yml
@@ -1,0 +1,13 @@
+
+# EC2 cinfiguration variable definations
+ec2_keypair: MyKeyPair1
+ec2_security_group: "default"
+ec2_region: "ap-south-1"
+ec2_instance_type: "t2.micro"
+ec2_image: ami-faedce95
+ec2_tag_Name: "Ansible"
+ec2_tag_Type: "Server"
+ec2_tag_Environment: "production"
+ec2_volume_type: "standard"
+ec2_volume_size: "8"
+

--- a/playbooks/Prov_EC2_playbook.yaml
+++ b/playbooks/Prov_EC2_playbook.yaml
@@ -1,0 +1,27 @@
+
+---
+- hosts:
+  - 127.0.0.1
+  connection: local
+  gather_facts: False
+  pre_tasks:
+    - include_vars: '../inventories/staging/host_vars/ec2_variables.yml'
+  vars:
+    count: 3
+  tasks:
+  - name: Launch new EC2 instance-{{count}}
+    local_action: ec2
+        keypair={{ec2_keypair}}
+        group={{ec2_security_group}}
+        instance_type={{ec2_instance_type}}
+        region={{ec2_region}}
+        image={{ec2_image}}
+        instance_tags='{"Name":"{{ec2_tag_Name}}","Type":"{{ec2_tag_Type}}","Environment":"{{ec2_tag_Environment}}"}'
+        wait=true
+        count={{count}}
+    #volumes:
+    #  - device_name= /dev/sda1
+    #    volume_type={{ ec2_volume_type }}
+    #    volume_size={{ ec2_volume_size }}
+    #    delete_on_termination=true
+    register: ec2


### PR DESCRIPTION
https://docs.ansible.com/ansible/latest/scenario_guides/guide_aws.html

https://dzone.com/articles/provision-aws-ec2-virtual-machines-with-ansible

https://github.com/devops-recipes/prov_aws_ec2_ansible/blob/master/ansible/ec2_prov_playbook.yml

http://allandenot.com/devops/2015/01/31/provisioning-ec2-hosts-with-ansible.html

(ansible2.0) root@dockervm1:~/ansible2.0/AnsibleWorkout# ansible-playbook playbooks/Prov_EC2_playbook.yaml -vvvv
Using /etc/ansible/ansible.cfg as config file
 [WARNING]: provided hosts list is empty, only localhost is available

Loaded callback default of type stdout, v2.0
1 plays in playbooks/Prov_EC2_playbook.yaml

PLAY ***************************************************************************

TASK [include_vars] ************************************************************
task path: /root/ansible2.0/AnsibleWorkout/playbooks/Prov_EC2_playbook.yaml:8
ok: [127.0.0.1] => {"ansible_facts": {"ec2_image": "ami-faedce95", "ec2_instance_type": "t2.micro", "ec2_keypair": "MyKeyPair1", "ec2_region": "ap-south-1", "ec2_security_group": "default", "ec2_tag_Environment": "production", "ec2_tag_Name": "Ansible", "ec2_tag_Type": "Server"}, "changed": false, "invocation": {"module_args": {"_raw_params": "../inventories/staging/host_vars/ec2_variables.yml"}, "module_name": "include_vars"}}

TASK [Launch new EC2 instance] *************************************************
task path: /root/ansible2.0/AnsibleWorkout/playbooks/Prov_EC2_playbook.yaml:17
ESTABLISH LOCAL CONNECTION FOR USER: root
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1534592544.76-204443486771081 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1534592544.76-204443486771081 `" )'
localhost PUT /tmp/tmpXuulXK TO /root/.ansible/tmp/ansible-tmp-1534592544.76-204443486771081/ec2
localhost EXEC /bin/sh -c 'LANG=en_IN LC_ALL=en_IN LC_MESSAGES=en_IN /root/ansible2.0/bin/python /root/.ansible/tmp/ansible-tmp-1534592544.76-204443486771081/ec2; rm -rf "/root/.ansible/tmp/ansible-tmp-1534592544.76-204443486771081/" > /dev/null 2>&1'
changed: [127.0.0.1 -> localhost] => {"changed": true, "instance_ids": ["i-0da83719bab75b287", "i-016aeac59a16c479a", "i-01bcb4366fb0db7c4"], "instances": [{"ami_launch_index": "1", "architecture": "x86_64", "block_device_mapping": {"/dev/sda1": {"delete_on_termination": false, "status": "attached", "volume_id": "vol-07e44bc06fdae49dc"}}, "dns_name": "ec2-13-233-13-172.ap-south-1.compute.amazonaws.com", "ebs_optimized": false, "groups": {"sg-62ac4208": "default"}, "hypervisor": "xen", "id": "i-0da83719bab75b287", "image_id": "ami-faedce95", "instance_type": "t2.micro", "kernel": null, "key_name": "MyKeyPair1", "launch_time": "2018-08-18T11:42:31.000Z", "placement": "ap-south-1a", "private_dns_name": "ip-172-31-19-178.ap-south-1.compute.internal", "private_ip": "172.31.19.178", "public_dns_name": "ec2-13-233-13-172.ap-south-1.compute.amazonaws.com", "public_ip": "13.233.13.172", "ramdisk": null, "region": "ap-south-1", "root_device_name": "/dev/sda1", "root_device_type": "ebs", "state": "running", "state_code": 16, "tags": {"Environment": "production", "Name": "Ansible", "Type": "Server"}, "tenancy": "default", "virtualization_type": "hvm"}, {"ami_launch_index": "0", "architecture": "x86_64", "block_device_mapping": {"/dev/sda1": {"delete_on_termination": false, "status": "attached", "volume_id": "vol-07b6deae08e091dd8"}}, "dns_name": "ec2-35-154-102-202.ap-south-1.compute.amazonaws.com", "ebs_optimized": false, "groups": {"sg-62ac4208": "default"}, "hypervisor": "xen", "id": "i-016aeac59a16c479a", "image_id": "ami-faedce95", "instance_type": "t2.micro", "kernel": null, "key_name": "MyKeyPair1", "launch_time": "2018-08-18T11:42:31.000Z", "placement": "ap-south-1a", "private_dns_name": "ip-172-31-28-176.ap-south-1.compute.internal", "private_ip": "172.31.28.176", "public_dns_name": "ec2-35-154-102-202.ap-south-1.compute.amazonaws.com", "public_ip": "35.154.102.202", "ramdisk": null, "region": "ap-south-1", "root_device_name": "/dev/sda1", "root_device_type": "ebs", "state": "running", "state_code": 16, "tags": {"Environment": "production", "Name": "Ansible", "Type": "Server"}, "tenancy": "default", "virtualization_type": "hvm"}, {"ami_launch_index": "2", "architecture": "x86_64", "block_device_mapping": {"/dev/sda1": {"delete_on_termination": false, "status": "attached", "volume_id": "vol-0a111d3ef2a10fbbe"}}, "dns_name": "ec2-13-232-248-121.ap-south-1.compute.amazonaws.com", "ebs_optimized": false, "groups": {"sg-62ac4208": "default"}, "hypervisor": "xen", "id": "i-01bcb4366fb0db7c4", "image_id": "ami-faedce95", "instance_type": "t2.micro", "kernel": null, "key_name": "MyKeyPair1", "launch_time": "2018-08-18T11:42:31.000Z", "placement": "ap-south-1a", "private_dns_name": "ip-172-31-16-217.ap-south-1.compute.internal", "private_ip": "172.31.16.217", "public_dns_name": "ec2-13-232-248-121.ap-south-1.compute.amazonaws.com", "public_ip": "13.232.248.121", "ramdisk": null, "region": "ap-south-1", "root_device_name": "/dev/sda1", "root_device_type": "ebs", "state": "running", "state_code": 16, "tags": {"Environment": "production", "Name": "Ansible", "Type": "Server"}, "tenancy": "default", "virtualization_type": "hvm"}], "invocation": {"module_args": {"assign_public_ip": false, "aws_access_key": null, "aws_secret_key": null, "count": 3, "count_tag": null, "ebs_optimized": false, "ec2_url": null, "exact_count": null, "group": ["default"], "group_id": null, "id": null, "image": "ami-faedce95", "instance_ids": null, "instance_profile_name": null, "instance_tags": {"Environment": "production", "Name": "Ansible", "Type": "Server"}, "instance_type": "t2.micro", "kernel": null, "key_name": "MyKeyPair1", "keypair": "MyKeyPair1", "monitoring": false, "network_interfaces": null, "placement_group": null, "private_ip": null, "profile": null, "ramdisk": null, "region": "ap-south-1", "security_token": null, "source_dest_check": true, "spot_price": null, "spot_type": "one-time", "spot_wait_timeout": 600, "state": "present", "tenancy": "default", "termination_protection": false, "user_data": null, "validate_certs": true, "volumes": null, "vpc_subnet_id": null, "wait": true, "wait_timeout": 300, "zone": null}, "module_name": "ec2"}, "tagged_instances": []}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=2    changed=1    unreachable=0    failed=0